### PR TITLE
WIP: attempt to test PyGrain based on https://github.com/apple/axlearn/pull/1318/files

### DIFF
--- a/axlearn/cloud/gcp/jobset_utils.py
+++ b/axlearn/cloud/gcp/jobset_utils.py
@@ -1,3 +1,4 @@
+
 # Copyright © 2025 Apple Inc.
 
 """Utilities for building Jobset specs."""
@@ -9,6 +10,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Optional, Sequence
 from urllib.parse import urlparse
+import re
 
 from absl import flags
 
@@ -84,6 +86,7 @@ class GCSFuseMount(VolumeMount):
             can wait to get a response from the server before timing out. Setting it to 0s means no
             limit.
         read_only: Whether the mount should be read-only.
+        mount_options: Comma-separated GCS FUSE mount options.
     """
 
     gcs_path: str
@@ -94,6 +97,7 @@ class GCSFuseMount(VolumeMount):
     ephemeral_gb: str = "5Gi"
     shared_memory: str = "1Gi"
     http_client_timeout: str = "0s"
+    mount_options: str = ""
 
 
 @dataclass(kw_only=True)
@@ -298,7 +302,21 @@ class SingleReplicatedJob(BaseReplicatedJob):
         # pylint: disable=missing-kwoa
         # pytype: disable=missing-parameter
         if fv.gcsfuse_mount_spec:
-            cfg.gcsfuse_mount = GCSFuseMount(**parse_kv_flags(fv.gcsfuse_mount_spec, delimiter="="))
+            specs = []
+            # This regex splits by comma, but only if the comma is not inside double quotes.
+            quote_aware_splitter = re.compile(r',(?=(?:[^"]*"[^"]*")*[^"]*$)')
+            for spec_group in fv.gcsfuse_mount_spec:
+                specs.extend(quote_aware_splitter.split(spec_group))
+            
+            # Parse the specs into a dictionary. This will preserve quotes in the values.
+            parsed_args = parse_kv_flags(specs, delimiter="=")
+
+            # If mount_options was parsed, remove the outer quotes from its value.
+            if "mount_options" in parsed_args:
+                parsed_args["mount_options"] = parsed_args["mount_options"].strip('"\'')
+
+            # Create the GCSFuseMount object with the cleaned arguments.
+            cfg.gcsfuse_mount = GCSFuseMount(**parsed_args)
         if fv.host_mount_spec:
             cfg.host_mounts = [
                 HostMount(**parse_kv_flags(item.split(","), delimiter="="))
@@ -563,6 +581,7 @@ class TPUReplicatedJob(SingleReplicatedJob):
             )
             # Parse GCSFuseMount path into bucket, prefix.
             parsed = urlparse(cfg.gcsfuse_mount.gcs_path)
+            gcsMountOptions = cfg.gcsfuse_mount.mount_options or f"only-dir={parsed.path.lstrip('/')},implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,kernel-list-cache-ttl-secs=-1,gcs-connection:http-client-timeout:{cfg.gcsfuse_mount.http_client_timeout}"
             # https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver#consume-ephemeral-volume-pod
             # Caveat: --implicit-dirs might have negative impacts on i/o performance. See
             # https://github.com/googlecloudplatform/gcsfuse/blob/master/docs/semantics.md .
@@ -578,7 +597,7 @@ class TPUReplicatedJob(SingleReplicatedJob):
                         volumeAttributes=dict(
                             bucketName=parsed.netloc,
                             # pylint: disable=line-too-long
-                            mountOptions=f"only-dir={parsed.path.lstrip('/')},implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,kernel-list-cache-ttl-secs=-1,gcs-connection:http-client-timeout:{cfg.gcsfuse_mount.http_client_timeout}",
+                            mountOptions=gcsMountOptions,
                             gcsfuseMetadataPrefetchOnMount="false",  # Improves first-time read.
                             disableMetrics="false",  # Enables GCSFuse metrics by default.
                         ),

--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -562,12 +562,26 @@ class Model(BaseModel):
                 logits: a float Tensor of shape [batch_size, seq_len, vocab_size]
                 hidden_states: a float Tensor of shape [batch_size, seq_len, hidden_dim]
         """
+        print(f"DEBUG: input_batch = {input_batch}", flush=True)
         self._constrain_input_batch(input_batch)
+        
         # TODO(markblee): Simplify by using consistent naming between `input_positions` and
         # `positions`, `input_segment_ids` and `segment_ids`.
-        # Decoder hidden states: [batch_size, target_len, hidden_dim].
-        decoder_batch = {**input_batch}
-        decoder_batch["positions"] = input_batch.get("input_positions")
+        
+        # Create decoder_batch by filtering out scalar fields
+        decoder_batch = {}
+        for key, value in input_batch.items():
+            # Only include non-scalar tensors in decoder_batch
+            if hasattr(value, 'ndim') and value.ndim > 0:
+                print(f"DEBUG: Including field '{key}' in decoder input", flush=True)
+                print(f"DEBUG: value = {value}, value.ndim = {value.ndim}", flush=True)
+                decoder_batch[key] = value
+            else:
+                print(f"DEBUG: Filtering out scalar field '{key}' from decoder input", flush=True)
+        
+        # Handle positions mapping
+        decoder_batch["positions"] = decoder_batch.get("input_positions")
+        
         return self.decoder(input_batch=decoder_batch)
 
     def _metrics(
@@ -599,9 +613,11 @@ class Model(BaseModel):
         """Applies sharding constraints in-place for relevant named tensors in the input batch."""
         mesh = thread_resources.env.physical_mesh  # type: ignore
         if mesh.empty or mesh.size == 1:
+            print("DEBUG: mesh.empty or mesh.size == 1.", flush=True)
             return
         cfg: Model.Config = self.config
         if cfg.batch_axis_names is None and cfg.seq_axis_names is None:
+            print("DEBUG: cfg.batch_axis_names and cfg.seq_axis_names are both None.", flush=True)
             return
 
         logging.log_first_n(
@@ -613,6 +629,7 @@ class Model(BaseModel):
         )
 
         for k, v in input_batch.items():
+            print(f"DEBUG: k = {k}, v = {v}, v.ndim = {v.ndim}", flush=True)
             if k in [
                 "input_ids",
                 "target_labels",

--- a/axlearn/common/input_base.py
+++ b/axlearn/common/input_base.py
@@ -240,6 +240,10 @@ class Input(Module):
         """
 
         def constrain_batch_axis(path: str, value: Tensor):
+            # Handle scalars - they have no batch dimension to constrain
+            if value.ndim == 0:
+                return with_sharding_constraint(value, PartitionSpec())
+            
             mesh = thread_resources.env.physical_mesh
             batch_partitions = math.prod(
                 mesh.shape[axis] for axis in jax.tree.leaves(self._partition_spec[0])

--- a/axlearn/common/input_base.py
+++ b/axlearn/common/input_base.py
@@ -187,6 +187,10 @@ class Input(Module):
         self._input_partitioner: Optional[InputPartitionFn] = maybe_instantiate(
             cfg.input_partitioner
         )
+        print(f"partition_spec = {self._partition_spec}", flush=True)
+        print(f"cfg.input_dispatcher = {cfg.input_dispatcher}", flush=True)
+        print(f"cfg.partition_spec = {cfg.partition_spec}", flush=True)
+        print(f"input_partitioner = {self._input_partitioner}", flush=True)
 
     def dataset(self) -> Iterable[Nested[Tensor]]:
         """Returns the input dataset, which should produce per-feed logical batches.

--- a/axlearn/common/input_grain.py
+++ b/axlearn/common/input_grain.py
@@ -874,6 +874,6 @@ def mixture_train_input_source(
         mixed_ds = sample_from_datasets(sources=sources, weights=weights)
 
         # Shard the mixed dataset
-        return mixed_ds
+        return mixed_ds.batch(4)
 
     return build_dataset_fn

--- a/axlearn/common/input_grain.py
+++ b/axlearn/common/input_grain.py
@@ -804,14 +804,6 @@ def mixture_train_input_source(
 
     def build_dataset_fn(
             dispatch_config: DispatchConfig,
-            *,
-            is_training: bool,
-            vocab_cfg: ConfigOr,
-            preprocessor: Union[ConfigOr, list[ConfigOr]],
-            data_mixture_components: Union[ConfigOr, list],
-            max_sequence_length: int,
-            replace_newlines_with: str = "<n>",
-            seed: Optional[int] = 42,
         ) -> Dataset:
         sources = []
         weights = []
@@ -831,7 +823,7 @@ def mixture_train_input_source(
             arrayrecord_files = [
                 os.path.join(arrayrecord_dataset_dir, f)
                 for f in all_files
-                if f.endswith(".arrayrecord")
+                if "array_record" in f
             ]
 
             # Create ArrayRecord dataset
@@ -869,10 +861,11 @@ def mixture_train_input_source(
 
             # Apply processor to the source dataset
             processor_fn = maybe_instantiate(processor_cfg)
-            source_ds = source_ds.map(processor_fn)
+            source_ds = processor_fn(source_ds)
 
-            # Repeat the dataset for mixing
-            source_ds = source_ds.repeat()
+            # Repeat the dataset for mixing.
+            # Commenting this out because 'MapIterDataset' object has no attribute 'repeat'
+            #source_ds = source_ds.repeat()
 
             sources.append(source_ds)
             weights.append(component.weight)
@@ -883,12 +876,4 @@ def mixture_train_input_source(
         # Shard the mixed dataset
         return mixed_ds
 
-    return config_for_function(build_dataset_fn).set(
-        is_training=is_training,
-        vocab_cfg=vocab_cfg,
-        preprocessor=preprocessor,
-        data_mixture_components=data_mixture_components,
-        max_sequence_length=max_sequence_length,
-        replace_newlines_with=replace_newlines_with,
-        seed=seed,
-    )
+    return build_dataset_fn

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -371,8 +371,10 @@ class SpmdTrainer(Module):
         return self._trainer_state_partition_specs
 
     def _train_step_input_partition_specs(self):
+        """Returns partition specs for input batch that handle scalars properly."""
         # Note that subclasses may override this method to set a partition spec for pjit which is
         # different from that of the input partition spec.
+        print(f"DEBUG: self.input.partition_spec = {self.input.partition_spec}", flush=True)
         return self.input.partition_spec
 
     def model_params_for_eval(self):

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -372,10 +372,27 @@ class SpmdTrainer(Module):
 
     def _train_step_input_partition_specs(self):
         """Returns partition specs for input batch that handle scalars properly."""
-        # Note that subclasses may override this method to set a partition spec for pjit which is
-        # different from that of the input partition spec.
-        print(f"DEBUG: self.input.partition_spec = {self.input.partition_spec}", flush=True)
-        return self.input.partition_spec
+        base_partition_spec = self.input.partition_spec
+        
+        # Get a sample batch to understand the structure
+        sample_batch = self.input.element_spec()
+        
+        def create_partition_spec_for_value(value, base_spec):
+            """Create appropriate partition spec based on value shape."""
+            if hasattr(value, 'shape') and len(value.shape) == 0:
+                # Scalar value - use empty PartitionSpec
+                return PartitionSpec()
+            else:
+                # Non-scalar value - use the base partition spec
+                return base_spec
+        
+        # Apply the partition spec logic to the entire batch structure
+        partition_specs = jax.tree_map(
+            lambda x: create_partition_spec_for_value(x, base_partition_spec),
+            sample_batch
+        )
+        
+        return partition_specs
 
     def model_params_for_eval(self):
         state = self.trainer_state

--- a/axlearn/common/trainer_config_modifier.py
+++ b/axlearn/common/trainer_config_modifier.py
@@ -5,9 +5,11 @@
 import json
 import logging
 import os
-from typing import Dict, Optional, Sequence, Union
+from typing import Callable, Dict, Optional, Sequence, Union
 
 from axlearn.common import config
+from axlearn.common import file_system as fs
+from axlearn.common import input_grain_text
 from axlearn.common.base_layer import RematSpec
 from axlearn.common.config import (
     REQUIRED,
@@ -20,6 +22,8 @@ from axlearn.common.config import (
     maybe_instantiate,
 )
 from axlearn.common.gradient_accumulation import with_minibatch_steps
+from axlearn.common.input_grain import Dataset
+from axlearn.common.input_grain_lm import windowed_packing
 from axlearn.common.metrics import MetricAccumulator
 from axlearn.common.quantized_dot_general.layers import (
     DenseGeneralBaseLayer,
@@ -370,7 +374,28 @@ class GrainConfigModifier(ConfigModifier):
         # Extract other relevant config parameters from tf_data_config, with fallbacks
         vocab_cfg = tf_data_config.vocab_cfg
         max_sequence_length = tf_data_config.max_sequence_length
-        preprocessor = config_for_function(input_grain_lm.text_to_lm_training_input).set(
+        
+        def partial_text_to_lm_training_input(
+            vocab: ConfigOr[input_grain_text.Vocabulary],
+            max_len: int,
+            window_size: int = 128,
+            max_padding_fraction: float = 1,
+            read_options: grain.ReadOptions = grain.ReadOptions(
+                num_threads=1, prefetch_buffer_size=16
+            ),
+            packing_fn: Callable = windowed_packing,
+        ) -> Callable[[Dataset], Dataset]:
+            return lambda ds: input_grain_lm.text_to_lm_training_input(
+                ds,
+                vocab=vocab,
+                max_len=max_len,
+                max_padding_fraction=max_padding_fraction,
+                window_size=window_size,
+                read_options=read_options,
+                packing_fn=packing_fn,
+            )
+
+        preprocessor = config_for_function(partial_text_to_lm_training_input).set(
             vocab=vocab_cfg,
             max_len=max_sequence_length,
             max_padding_fraction=tf_data_config.preprocessor.max_padding_fraction,

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -778,10 +778,21 @@ def dispatch_input_batch(
         n=1,
     )
 
-    # Constrain the input batch.
-    input_batch = jax.tree.map(
-        lambda x: with_sharding_constraint(x, PartitionSpec(batch_axis_names)), input_batch
-    )
+    # Constrain the input batch with appropriate partition specs for each element
+    def apply_sharding_constraint(x):
+        """Apply appropriate sharding constraint based on tensor rank."""
+        # Handle scalars - they cannot be sharded
+        if hasattr(x, 'ndim') and x.ndim == 0:
+            return with_sharding_constraint(x, PartitionSpec())
+        # Handle non-tensor types (shouldn't happen, but be safe)
+        elif not hasattr(x, 'ndim'):
+            logging.warning(f"Unexpected non-tensor type in input batch: {type(x)}")
+            return x
+        else:
+            # Non-scalar tensor - use the batch axis names
+            return with_sharding_constraint(x, PartitionSpec(batch_axis_names))
+    
+    input_batch = jax.tree.map(apply_sharding_constraint, input_batch)
 
     def traverse_and_dispatch(data: NestedTensor) -> NestedTensor:
         if isinstance(data, dict):
@@ -819,7 +830,7 @@ def data_partition_type_to_spec(
 def host_to_global_array(
     host_arrays: Nested[Union[np.ndarray, Tensor]],
     *,
-    partition: Union[PartitionSpec, DataPartitionType] = DataPartitionType.FULL,
+    partition: Union[PartitionSpec, DataPartitionType, Nested[PartitionSpec]] = DataPartitionType.FULL,
 ) -> Nested[Tensor]:
     """Converts the given host device arrays to global device arrays.
 
@@ -829,7 +840,9 @@ def host_to_global_array(
         host_arrays: A nested tree of device arrays in host memory. Usually these present the
             per-host portion of the global input batch. We currently assume that per-host portions
             form a uniform sharding across the batch.
-        partition: How the global array should be partitioned.
+        partition: How the global array should be partitioned. Can be:
+            - A single PartitionSpec or DataPartitionType applied to all arrays
+            - A nested structure of PartitionSpecs matching the structure of host_arrays
 
     Returns:
         A nested tree with the same structure as `host_arrays`, but global device arrays at the
@@ -855,10 +868,21 @@ def host_to_global_array(
     print(f"  - Process count: {jax.process_count()}", flush=True)
     print(f"  - Process index: {jax.process_index()}", flush=True)
     
-    partition_specs = complete_partition_spec_tree(
-        jax.tree_util.tree_structure(host_arrays),
-        data_partition_type_to_spec(partition),
-    )
+    # Handle the case where partition is already a nested structure of PartitionSpecs
+    if isinstance(partition, (dict, tuple, list)) or (
+        hasattr(partition, '__class__') and 
+        hasattr(partition.__class__, '_fields')  # NamedTuple check
+    ):
+        # partition is already a nested structure - use it directly
+        partition_specs = partition
+        print(f"DEBUG: Using nested partition structure directly", flush=True)
+    else:
+        # partition is a single spec - apply it to the entire tree structure
+        partition_specs = complete_partition_spec_tree(
+            jax.tree_util.tree_structure(host_arrays),
+            data_partition_type_to_spec(partition),
+        )
+        print(f"DEBUG: Created partition specs from single partition", flush=True)
     
     # Debug: Print partition information
     print(f"DEBUG: Partition information:", flush=True)
@@ -884,14 +908,27 @@ def host_to_global_array(
                 global_shape=x.shape,  # Keep original scalar shape
             )
 
-        if partition == DataPartitionType.FULL:
-            global_shape = (x.shape[0] * process_count, *x.shape[1:])
-        elif partition == DataPartitionType.REPLICATED:
-            global_shape = (x.shape[0], *x.shape[1:])
+        # For non-scalars, determine the partition type from the original partition parameter
+        # We need to figure out what the original partition intent was
+        if isinstance(partition, DataPartitionType):
+            current_partition_type = partition
         elif isinstance(partition, PartitionSpec):
-            global_shape = None  # Allow jax to infer.
+            # If it's a single PartitionSpec, treat as FULL partitioning
+            current_partition_type = DataPartitionType.FULL
         else:
-            raise NotImplementedError(f"Unsupported partition: {partition}")
+            # If it's a nested structure, we can't easily determine the intent
+            # Default to inferring from the partition_spec
+            if partition_spec == PartitionSpec():
+                current_partition_type = DataPartitionType.REPLICATED
+            else:
+                current_partition_type = DataPartitionType.FULL
+
+        if current_partition_type == DataPartitionType.FULL:
+            global_shape = (x.shape[0] * process_count, *x.shape[1:])
+        elif current_partition_type == DataPartitionType.REPLICATED:
+            global_shape = (x.shape[0], *x.shape[1:])
+        else:
+            global_shape = None  # Allow jax to infer.
             
         print(f"  - Calculated global_shape: {global_shape}", flush=True)
         

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -816,7 +816,6 @@ def data_partition_type_to_spec(
     else:
         raise NotImplementedError(f"Unsupported partition: {partition}")
 
-
 def host_to_global_array(
     host_arrays: Nested[Union[np.ndarray, Tensor]],
     *,
@@ -847,13 +846,44 @@ def host_to_global_array(
         )
 
     mesh = thread_resources.env.physical_mesh
+    
+    # Debug: Print mesh information
+    print(f"DEBUG: Mesh configuration:", flush=True)
+    print(f"  - Mesh shape: {mesh.shape}", flush=True)
+    print(f"  - Mesh axis names: {mesh.axis_names}", flush=True)
+    print(f"  - Mesh devices shape: {getattr(mesh, 'devices', 'N/A')}", flush=True)
+    print(f"  - Process count: {jax.process_count()}", flush=True)
+    print(f"  - Process index: {jax.process_index()}", flush=True)
+    
     partition_specs = complete_partition_spec_tree(
         jax.tree_util.tree_structure(host_arrays),
         data_partition_type_to_spec(partition),
     )
+    
+    # Debug: Print partition information
+    print(f"DEBUG: Partition information:", flush=True)
+    print(f"  - Original partition: {partition}", flush=True)
+    print(f"  - Partition specs structure: {jax.tree_util.tree_structure(partition_specs)}", flush=True)
+    
     process_count = jax.process_count()
 
     def make_array(x: np.ndarray, partition_spec: PartitionSpec):
+        print(f"DEBUG: Processing array with shape {x.shape}, dtype {x.dtype}", flush=True)
+        print(f"  - Partition spec: {partition_spec}", flush=True)
+        
+        # Handle scalar arrays specially
+        if x.ndim == 0:  # Scalar array
+            print(f"DEBUG: Handling scalar array with dtype {x.dtype}", flush=True)
+            # For scalars, use a replicated partition spec (no sharding)
+            scalar_partition_spec = PartitionSpec()
+            named_sharding = jax.sharding.NamedSharding(mesh, scalar_partition_spec)
+            
+            return jax.make_array_from_process_local_data(
+                sharding=named_sharding,
+                local_data=x,
+                global_shape=x.shape,  # Keep original scalar shape
+            )
+
         if partition == DataPartitionType.FULL:
             global_shape = (x.shape[0] * process_count, *x.shape[1:])
         elif partition == DataPartitionType.REPLICATED:
@@ -862,13 +892,76 @@ def host_to_global_array(
             global_shape = None  # Allow jax to infer.
         else:
             raise NotImplementedError(f"Unsupported partition: {partition}")
-        return jax.make_array_from_process_local_data(
-            sharding=jax.sharding.NamedSharding(mesh, partition_spec),
-            local_data=x,
-            global_shape=global_shape,
-        )
+            
+        print(f"  - Calculated global_shape: {global_shape}", flush=True)
+        
+        # Create the NamedSharding and print debug info
+        try:
+            named_sharding = jax.sharding.NamedSharding(mesh, partition_spec)
+            print(f"  - NamedSharding created successfully", flush=True)
+            print(f"  - NamedSharding mesh: {named_sharding.mesh}", flush=True)
+            print(f"  - NamedSharding spec: {named_sharding.spec}", flush=True)
+            
+            # Try to get more sharding info before the failing call
+            if global_shape is not None:
+                print(f"  - Attempting to create array with global_shape: {global_shape}", flush=True)
+                try:
+                    # This is where the error likely occurs - let's try to get more info
+                    print(f"  - Checking sharding compatibility...", flush=True)
+                    # Check if we can get devices_indices_map without error
+                    print(f"  - Getting addressable devices indices map...", flush=True)
+                    devices_map = named_sharding.addressable_devices_indices_map(global_shape)
+                    print(f"  - Addressable devices map obtained successfully", flush=True)
+                except Exception as e:
+                    print(f"  - ERROR in addressable_devices_indices_map: {e}", flush=True)
+                    print(f"  - Error type: {type(e)}", flush=True)
+                    # Let's try to understand the mesh/spec mismatch
+                    print(f"  - Mesh axis names: {mesh.axis_names}", flush=True)
+                    print(f"  - Partition spec details: {partition_spec}", flush=True)
+                    if hasattr(partition_spec, '__dict__'):
+                        print(f"  - Partition spec attributes: {partition_spec.__dict__}", flush=True)
+                    raise
+            
+        except Exception as e:
+            print(f"  - ERROR creating NamedSharding: {e}", flush=True)
+            print(f"  - Error type: {type(e)}", flush=True)
+            raise
+        
+        try:
+            result = jax.make_array_from_process_local_data(
+                sharding=named_sharding,
+                local_data=x,
+                global_shape=global_shape,
+            )
+            print(f"  - Array created successfully with shape: {result.shape}", flush=True)
+            return result
+        except Exception as e:
+            print(f"  - ERROR in make_array_from_process_local_data: {e}", flush=True)
+            print(f"  - Error type: {type(e)}", flush=True)
+            print(f"  - Local data shape: {x.shape}", flush=True)
+            print(f"  - Local data dtype: {x.dtype}", flush=True)
+            print(f"  - Global shape: {global_shape}", flush=True)
+            print(f"  - Named sharding: {named_sharding}", flush=True)
+            raise
 
-    return jax.tree.map(make_array, host_arrays, partition_specs)
+    # Debug: Print host_arrays structure before processing
+    print(f"DEBUG: Host arrays structure:", flush=True)
+    try:
+        host_arrays_shapes = jax.tree.map(lambda x: (x.shape, x.dtype) if hasattr(x, 'shape') else type(x), host_arrays)
+        print(f"  - Host arrays shapes and dtypes: {host_arrays_shapes}", flush=True)
+    except Exception as e:
+        print(f"  - Could not get host arrays shapes: {e}", flush=True)
+    
+    print(f"DEBUG: Starting jax.tree.map processing...", flush=True)
+    
+    try:
+        result = jax.tree.map(make_array, host_arrays, partition_specs)
+        print(f"DEBUG: jax.tree.map completed successfully", flush=True)
+        return result
+    except Exception as e:
+        print(f"DEBUG: ERROR in jax.tree.map: {e}", flush=True)
+        print(f"DEBUG: Error type: {type(e)}", flush=True)
+        raise
 
 
 def host_to_global_specs(

--- a/axlearn/experiments/text/gpt/common.py
+++ b/axlearn/experiments/text/gpt/common.py
@@ -739,7 +739,6 @@ def get_trainer_config_fn(
                 path_rank_to_partition={
                     # Note: the batch axes are different here than in `cfg.batch_axis_names`,
                     # as we partition sequence dim over `seq`.
-                    (None, 0): PartitionSpec(),
                     (None, 1): PartitionSpec(("data", "expert", "fsdp")),
                     (None, 2): PartitionSpec(("data", "expert", "fsdp"), "seq"),
                 }

--- a/axlearn/experiments/text/gpt/common.py
+++ b/axlearn/experiments/text/gpt/common.py
@@ -739,6 +739,7 @@ def get_trainer_config_fn(
                 path_rank_to_partition={
                     # Note: the batch axes are different here than in `cfg.batch_axis_names`,
                     # as we partition sequence dim over `seq`.
+                    (None, 0): PartitionSpec(),
                     (None, 1): PartitionSpec(("data", "expert", "fsdp")),
                     (None, 2): PartitionSpec(("data", "expert", "fsdp"), "seq"),
                 }

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -31,6 +31,7 @@ from axlearn.common.attention import (
     RoFormerQKVLinear,
     StackedTransformerLayer,
 )
+from jax.sharding import PartitionSpec
 from axlearn.common.base_layer import RematSpec
 from axlearn.common.config import config_for_function
 from axlearn.common.decoder import LmHead
@@ -1107,6 +1108,41 @@ def trainer_configs(
                     convert_training_input=True,
                 )
                 cfg = grain_modifier.instantiate()(cfg)
+                
+                # For the grain pipeline, we must explicitly set the partition_spec on the
+                # input_dispatcher, which provides the sharding rules to the trainer
+                # for the host-to-device transfer.
+                complete_spec = {
+                    # Shard 1D tensors like input_ids and target_labels along the 'data' axis.
+                    "input_ids": PartitionSpec("data"),
+                    "target_labels": PartitionSpec("data"),
+                    # Replicate the 0D scalar 'target_num_bytes' by providing an empty PartitionSpec.
+                    "target_num_bytes": PartitionSpec(),
+                }
+
+                # Set the partition_spec directly on the dispatcher's config.
+                cfg.input.input_dispatcher.set(partition_spec=complete_spec)
+                
+                # Also set it on the parent input config for consistency. This ensures
+                # that if the dispatcher is not used for some reason, the correct spec is still found.
+                cfg.input.set(partition_spec=complete_spec)
+                
+                # For the grain pipeline, we must explicitly set the partition_spec on the
+                # input_dispatcher, which provides the sharding rules to the trainer.
+                # complete_spec = {
+                #     # Shard 1D tensors along the 'data' axis.
+                #     "input_ids": PartitionSpec("data"),
+                #     "target_labels": PartitionSpec("data"),
+                #     # Replicate the 0D scalar by providing an empty PartitionSpec.
+                #     "target_num_bytes": PartitionSpec(),
+                # }
+
+                # # Set the partition_spec directly on the dispatcher's config.
+                # cfg.input.input_dispatcher.set(partition_spec=complete_spec)
+                
+                # # Also set it on the parent input config to ensure consistency.
+                # cfg.input.set(partition_spec=complete_spec)
+                # print(f"Applied complete partition spec for grain input: {cfg.input.input_partitioner}", flush=True)
 
                 # Configure grain-specific input processing settings
                 # pylint: disable=cell-var-from-loop

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -1088,13 +1088,10 @@ def trainer_configs(
 
             def make_grain_config(base_config_name: str) -> SpmdTrainer.Config:
                 """Make a grain input processor variant of the base config.
-
                 This configuration uses the grain input processing framework for
                 improved data loading and preprocessing performance.
-
                 Args:
                     base_config_name: The base config name.
-
                 Returns:
                     A trainer config that uses grain input processing.
                 """
@@ -1113,12 +1110,23 @@ def trainer_configs(
                 # pylint: disable=cell-var-from-loop
                 # Adjust batch size for grain processing if needed
                 for evaler in cfg.evalers.values():
-                    if hasattr(evaler.input, 'input_dispatcher'):
+                    if hasattr(evaler.input, "input_dispatcher"):
                         evaler.input.input_dispatcher.global_logical_batch_size //= (
                             64 if version in (Version.V3, Version.V3_TIKTOKEN) else 16
                         )
                 # pylint: enable=cell-var-from-loop
                 return cfg
+
+            # Make grain config
+            make_grain_config_func = functools.partial(make_grain_config, config_name)
+            config_map[f"{config_name}-grain"] = make_grain_config_func
+
+            # Make grain configs for FP8
+            if f"{config_name}-fp8" in config_map:
+                make_grain_fp8_config_func = functools.partial(
+                    make_grain_config, f"{config_name}-fp8"
+                )
+                config_map[f"{config_name}-fp8-grain"] = make_grain_fp8_config_func
 
             # Make grain config
             make_grain_config_func = functools.partial(make_grain_config, config_name)

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -1108,41 +1108,6 @@ def trainer_configs(
                     convert_training_input=True,
                 )
                 cfg = grain_modifier.instantiate()(cfg)
-                
-                # For the grain pipeline, we must explicitly set the partition_spec on the
-                # input_dispatcher, which provides the sharding rules to the trainer
-                # for the host-to-device transfer.
-                complete_spec = {
-                    # Shard 1D tensors like input_ids and target_labels along the 'data' axis.
-                    "input_ids": PartitionSpec("data"),
-                    "target_labels": PartitionSpec("data"),
-                    # Replicate the 0D scalar 'target_num_bytes' by providing an empty PartitionSpec.
-                    "target_num_bytes": PartitionSpec(),
-                }
-
-                # Set the partition_spec directly on the dispatcher's config.
-                cfg.input.input_dispatcher.set(partition_spec=complete_spec)
-                
-                # Also set it on the parent input config for consistency. This ensures
-                # that if the dispatcher is not used for some reason, the correct spec is still found.
-                cfg.input.set(partition_spec=complete_spec)
-                
-                # For the grain pipeline, we must explicitly set the partition_spec on the
-                # input_dispatcher, which provides the sharding rules to the trainer.
-                # complete_spec = {
-                #     # Shard 1D tensors along the 'data' axis.
-                #     "input_ids": PartitionSpec("data"),
-                #     "target_labels": PartitionSpec("data"),
-                #     # Replicate the 0D scalar by providing an empty PartitionSpec.
-                #     "target_num_bytes": PartitionSpec(),
-                # }
-
-                # # Set the partition_spec directly on the dispatcher's config.
-                # cfg.input.input_dispatcher.set(partition_spec=complete_spec)
-                
-                # # Also set it on the parent input config to ensure consistency.
-                # cfg.input.set(partition_spec=complete_spec)
-                # print(f"Applied complete partition spec for grain input: {cfg.input.input_partitioner}", flush=True)
 
                 # Configure grain-specific input processing settings
                 # pylint: disable=cell-var-from-loop

--- a/patches/shard_map.py.patch
+++ b/patches/shard_map.py.patch
@@ -1,0 +1,27 @@
+--- shard_map_orig.py	2025-06-18 01:27:00.782665547 +0000
++++ shard_map.py	2025-06-18 01:26:06.798346281 +0000
+@@ -1793,10 +1793,10 @@
+ ) -> tuple[core.JaxprEqn, core.JaxprEqn, Sequence[bool], Sequence[bool],
+            list[core.Var]]:
+   jaxpr, mesh = eqn.params['jaxpr'], eqn.params['mesh']
+-  auto = eqn.params['auto']
+-  with _extend_axis_env(mesh, auto):
++  manual_axes = frozenset()
++  with (_extend_axis_env(mesh, manual_axes), use_abstract_mesh(_as_manual_mesh(mesh, manual_axes))):
+     jaxpr_known, jaxpr_staged, unks_out, inst_out, num_res = \
+-        pe.partial_eval_jaxpr_custom(jaxpr, unks_in, inst_in, False, False, saveable)
++      pe.partial_eval_jaxpr_custom(jaxpr, unks_in, inst_in, False, False, saveable)
+   num_out_primals = len(jaxpr_known.outvars) - num_res
+   in_fwd = pe._jaxpr_forwarding(jaxpr_known)[num_out_primals:]
+   out_vars, res_vars = split_list(jaxpr_known.outvars, [num_out_primals])
+@@ -1804,8 +1804,8 @@
+   out_fwd = [idx_map.get(id(v)) for v in res_vars]
+   which = [f1 is None and f2 is None for f1, f2 in zip(in_fwd, out_fwd)]
+   mesh = eqn.params['mesh']
+-  with (_extend_axis_env(mesh, auto),
+-        use_abstract_mesh(_as_manual_mesh(mesh, auto))):
++  with (_extend_axis_env(mesh, manual_axes),
++        use_abstract_mesh(_as_manual_mesh(mesh, frozenset()))):
+     jaxpr_known = pe.prune_jaxpr_outputs(jaxpr_known, [True] * num_out_primals + which)
+     jaxpr_known, jaxpr_staged = _add_reshapes(which, jaxpr_known, jaxpr_staged)
+   jaxpr_known = core.remove_named_axis_effects(jaxpr_known, mesh.axis_names)


### PR DESCRIPTION
Creating this WIP PR to stage the diff against https://github.com/apple/axlearn/pull/1318/files that attempts to kick off a Grain pipeline job on TPU. Needed to make a few code changes to get all errors resolved in the setup stage until the actual training stage.

Stuck at the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/root/axlearn/common/launch_trainer_main.py", line 22, in <module>
    app.run(main)
  File "/opt/venv/lib/python3.10/site-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/opt/venv/lib/python3.10/site-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/root/axlearn/common/launch_trainer_main.py", line 17, in main
    launch_trainer.run_trainer(trainer_config)
  File "/root/axlearn/common/launch_trainer.py", line 152, in run_trainer
    output = trainer.run(prng_key)
  File "/root/axlearn/common/traceback_util.py", line 293, in stack_annotation_wrapper
    return fn(*args, **kwargs)
  File "/root/axlearn/common/module.py", line 598, in wrap_method_fn
    return method_fn_in_context(self, *args, **kwargs)
  File "/root/axlearn/common/traceback_util.py", line 293, in stack_annotation_wrapper
    return fn(*args, **kwargs)
  File "/root/axlearn/common/traceback_util.py", line 168, in in_context_exception_wrapper
    return fn(*args, **kwargs)
  File "/root/axlearn/common/traceback_util.py", line 293, in stack_annotation_wrapper
    return fn(*args, **kwargs)
  File "/root/axlearn/common/module.py", line 560, in _call_method_in_context
    return method_fn(module, *args, **kwargs)
  File "/root/axlearn/common/traceback_util.py", line 293, in stack_annotation_wrapper
    return fn(*args, **kwargs)
  File "/root/axlearn/common/trainer.py", line 606, in run
    utils.host_to_global_array(
  File "/root/axlearn/common/utils.py", line 871, in host_to_global_array
    return jax.tree.map(make_array, host_arrays, partition_specs)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/tree.py", line 155, in map
    return tree_util.tree_map(f, tree, *rest, is_leaf=is_leaf)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/tree_util.py", line 358, in tree_map
    return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/tree_util.py", line 358, in <genexpr>
    return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))
  File "/root/axlearn/common/utils.py", line 865, in make_array
    return jax.make_array_from_process_local_data(
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/array.py", line 985, in make_array_from_process_local_data
    addressable_shards = sharding.addressable_devices_indices_map(global_shape)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/sharding.py", line 163, in addressable_devices_indices_map
    return _addressable_devices_indices_map(self, global_shape)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/util.py", line 337, in wrapper
    return cached(config.trace_context() if trace_context_in_key else _ignore(),
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/util.py", line 331, in cached
    return f(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/sharding.py", line 36, in _addressable_devices_indices_map
    global_map = sharding.devices_indices_map(global_shape)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/sharding.py", line 171, in devices_indices_map
    return common_devices_indices_map(self, global_shape)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/util.py", line 337, in wrapper
    return cached(config.trace_context() if trace_context_in_key else _ignore(),
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/util.py", line 331, in cached
    return f(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/sharding.py", line 48, in common_devices_indices_map
    s.shard_shape(global_shape)  # raises a good error message
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/sharding.py", line 188, in shard_shape
    return _common_shard_shape(self, global_shape)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/util.py", line 337, in wrapper
    return cached(config.trace_context() if trace_context_in_key else _ignore(),
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/util.py", line 331, in cached
    return f(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/sharding.py", line 57, in _common_shard_shape
    hlo_sharding = self._to_xla_hlo_sharding(len(global_shape))
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/named_sharding.py", line 242, in _to_xla_hlo_sharding
    return named_sharding_to_xla_hlo_sharding(self, num_dimensions)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/util.py", line 337, in wrapper
    return cached(config.trace_context() if trace_context_in_key else _ignore(),
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/util.py", line 331, in cached
    return f(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/jax/_src/named_sharding.py", line 430, in named_sharding_to_xla_hlo_sharding
    new_mesh_shape[pos] *= mesh_shape[name]
IndexError: list index out of range
```

The full axlearn command is 

```
axlearn gcp launch run --cluster=${CLUSTER} \
        --runner_name=gke_tpu_single \
        --name=${NAME} \
        --instance_type=tpu-v6e-256 \
        --max_tries=20 \
  --queue=multislice-queue \
  --priority_class=high \
  --service_account=axlearn-scale-testing \
        --num_replicas=$NUM_REPLICAS \
	  --gcsfuse_mount_spec=gcs_path=gs://tess-apple-southamerica-west1/tensorflow_datasets,mount_path=/tmp/tensorflow_datasets \
        --bundler_spec=allow_dirty=True \
        --bundler_type=artifactregistry --bundler_spec=image=tpu \
        --bundler_spec=dockerfile=Dockerfile --bundler_spec=target=tpu \
        -- "ulimit -n 1048576; ulimit -c 0; patch /opt/venv/lib/python3.10/site-packages/jax/experimental/shard_map.py -p0 < patches/shard_map.py.patch; python3 -m axlearn.common.launch_trainer_main" \
          --module=text.gpt.c4_trainer \
          --config=fuji-7B-v2-flash-grain \
          --trainer_dir=${OUTPUT_DIR} \
          --data_dir=/tmp/tensorflow_datasets  \
          --jax_backend=tpu \
          --trace_at_steps=50,101,150 \
   --recorder_type=axlearn.cloud.gcp.measurement:goodput \
          --recorder_spec=name=goodput_$NAME \
          --recorder_spec=upload_dir=$OUTPUT_DIR/summaries \
          --recorder_spec=upload_interval=30 \
          --recorder_spec=rolling_window_size=3600,86400,259200 \
          --mesh_selector=tpu-v6e-256-4
```